### PR TITLE
Remove simply.com

### DIFF
--- a/dns-blacklist.txt
+++ b/dns-blacklist.txt
@@ -10366,7 +10366,6 @@ optimize.adpushup.com
 optimizedby.brealtime.com
 optimizedby.rmxads.com
 optimized-by.rubiconproject.com
-optimized-by.simply.com
 optimized-by.vitalads.net
 optimized.by.vitalads.net
 optimize.indieclick.com


### PR DESCRIPTION
We aquired simply.com and are working on launching a webhosting project on it. However the domain is blocked by you, due to past advertising activity (before we bought it).

Can you delist the domain from your blocklists?