### PR TITLE
fix(whitelist): invalid amplitude link

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -66,7 +66,7 @@ aws.amazon.com
 amplitude.com
 api-sr.amplitude.com
 api.amplitude.com
-www..amplitude.com
+www.amplitude.com
 
 # [ Appcenter (Microsoft) ]
 appcenter.ms


### PR DESCRIPTION
checked blocky logs and found warnings with parse errors like this
```
WARN list_cache: parse error: line 69: 3 errors occurred:
	* invalid domain name: www..amplitude.com
	* invalid ip: www..amplitude.com
	* unsupported wildcard 'www..amplitude.com': must start with '*.' and contain no other '*'
```