### PR TITLE
Remove .. typos from amplitude and optimizely

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -66,7 +66,7 @@ aws.amazon.com
 amplitude.com
 api-sr.amplitude.com
 api.amplitude.com
-www..amplitude.com
+www.amplitude.com
 
 # [ Appcenter (Microsoft) ]
 appcenter.ms
@@ -766,7 +766,7 @@ www.oplata.info
 
 # [ Optimizely ]
 optimizely.com
-www..optimizely.com
+www.optimizely.com
 
 # [ Oszone ]
 oszone.net


### PR DESCRIPTION
www..domain is an invalid URL and breaks parsing the list